### PR TITLE
[WMSG-362]feature(interactive_menu): add menu with send-receive

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -217,8 +217,14 @@ func NewFlowManager() (outApp *FlowManager, outErr error) {
 	if err != nil {
 		return nil, err
 	}
-	fm.imServer = im.NewServer(fm.id, fm.Config().DiscoverySettings.Url, fm.eventQueue.ConsumeIM(),
-		fm.log, t, fm.Store.Session())
+	fm.imServer = im.NewServer(
+		fm.id,
+		fm.Config().DiscoverySettings.Url,
+		fm.eventQueue.ConsumeIM(),
+		fm.log,
+		t,
+		fm.Store.Session(),
+	)
 
 	if len(fm.Config().WebHook.Addr) > 1 {
 		fm.httpServer = http.NewServer(fm, fm.Config().WebHook.Addr)

--- a/app/cc/client_test.go
+++ b/app/cc/client_test.go
@@ -7,7 +7,7 @@ import (
 func Test(t *testing.T) {
 	t.Log("CC")
 
-	cc := NewCCManager("10.9.8.111:8500")
+	cc := NewCCManager("10.9.8.111:8500", nil)
 	cc.Start()
 	cc.Agent().Pause(1, 12, "", 14)
 	defer cc.Stop()

--- a/model/im.go
+++ b/model/im.go
@@ -1,6 +1,14 @@
 package model
 
-import "context"
+import (
+	"context"
+	"time"
+)
+
+const (
+	IMEventTypeMessage  string = "message"
+	IMEventTypeCallback string = "callback"
+)
 
 type IMDialog interface {
 	Connection
@@ -22,7 +30,6 @@ type IMDialog interface {
 	Export(ctx context.Context, vars []string) (Response, *AppError)
 	UnSet(ctx context.Context, varKeys []string) (Response, *AppError)
 	TreadInfo() ThreadInfo
-	LastMessages(limit int) []ChatMessage
 	GetQueueKey() *InQueueKey
 	SetQueue(*InQueueKey) bool
 	DumpExportVariables() map[string]string
@@ -52,14 +59,39 @@ type CCQueueEvent struct {
 	Result    string `json:"result"`
 }
 
-// MessageWrapper представляє кореневий об'єкт
-type MessageWrapper struct {
-	ID       string  `json:"id"`
-	Message  Message `json:"payload"`
-	UserID   string  `json:"user_id"`
-	DomainID int64   `json:"domain_id"`
-	Echo     bool    `json:"echo"`
+type IMEventWrapper interface {
+	GetID() string
+	GetUserID() string
+	GetDomainID() int64
+	IsEcho() bool
+	GetPayload() IMEvent
+	GetType() string
 }
+
+type IMEvent interface {
+	GetThreadID() string
+	MessageID() string
+	Sender() ImEndpoint
+	Receivers() []ImEndpoint
+	Message() Message
+}
+
+// MessageWrapper представляє кореневий об'єкт
+type MessageWrapper[T IMEvent] struct {
+	ID       string `json:"id"`
+	Message  T      `json:"payload"`
+	UserID   string `json:"user_id"`
+	DomainID int64  `json:"domain_id"`
+	Echo     bool   `json:"echo"`
+	Type     string `json:"-"`
+}
+
+func (w MessageWrapper[T]) GetID() string       { return w.ID }
+func (w MessageWrapper[T]) GetUserID() string   { return w.UserID }
+func (w MessageWrapper[T]) GetDomainID() int64  { return w.DomainID }
+func (w MessageWrapper[T]) IsEcho() bool        { return w.Echo }
+func (w MessageWrapper[T]) GetPayload() IMEvent { return w.Message }
+func (w MessageWrapper[T]) GetType() string     { return w.Type }
 
 // Message описує вкладений об'єкт повідомлення
 type Message struct {
@@ -73,6 +105,12 @@ type Message struct {
 	Subject     string       `json:"subject"`
 	Description string       `json:"description"`
 }
+
+func (m Message) GetThreadID() string     { return m.ThreadID }
+func (m Message) MessageID() string       { return m.ID }
+func (m Message) Sender() ImEndpoint      { return m.From }
+func (m Message) Receivers() []ImEndpoint { return m.To }
+func (m Message) Message() Message        { return m }
 
 type SystemMessageOutbound struct {
 	Type     string         `json:"type"`
@@ -90,3 +128,20 @@ type ImEndpoint struct {
 	MemberID string `json:"member_id"`
 	Role     int    `json:"role"`
 }
+
+type InteractiveCallback struct {
+	ReactedBy    ImEndpoint `json:"reacted_by"`
+	Receiver     ImEndpoint `json:"receiver"`
+	InReplyTo    string     `json:"in_reply_to"`
+	ThreadID     string     `json:"thread_id"`
+	ButtonCode   string     `json:"button_code"`
+	CallbackData string     `json:"callback_data"`
+	ReactedAt    time.Time  `json:"reacted_at"`
+	DomainID     int
+}
+
+func (c InteractiveCallback) GetThreadID() string     { return c.ThreadID }
+func (c InteractiveCallback) MessageID() string       { return c.InReplyTo }
+func (c InteractiveCallback) Sender() ImEndpoint      { return c.ReactedBy }
+func (c InteractiveCallback) Message() Message        { return Message{Text: c.ButtonCode} }
+func (c InteractiveCallback) Receivers() []ImEndpoint { return []ImEndpoint{c.Receiver} }

--- a/model/im_interactive.go
+++ b/model/im_interactive.go
@@ -1,19 +1,13 @@
 package model
 
-type SendInteractiveRequest struct {
-	Interactive Interactive    `json:"interactive"`
-	Body        string         `json:"body"`
-	Metadata    map[string]any `json:"metadata"`
-}
-
 type Interactive struct {
 	Documents *Documents `json:"documents,omitempty"`
 	Images    *Images    `json:"images,omitempty"`
 
-	SingleUse bool `json:"single_use"`
+	SingleUse bool `json:"singleUse"`
 
 	Markup    *KeyboardMarkup    `json:"markup,omitempty"`
-	ListReply *KeyboardListReply `json:"list_reply,omitempty"`
+	ListReply *KeyboardListReply `json:"listReply,omitempty"`
 }
 
 type Documents struct {
@@ -24,17 +18,8 @@ type Images struct {
 	Images []File `json:"images"`
 }
 
-type KeyboardMarkup struct {
-	Rows []KeyboardRow `json:"rows"`
-}
-
 type KeyboardRow struct {
 	Buttons []KeyboardButton `json:"buttons"`
-}
-
-type KeyboardListReply struct {
-	MainButtonTitle string                   `json:"main_button_title"`
-	Sections        []KeyboardRowWithSection `json:"sections"`
 }
 
 type KeyboardRowWithSection struct {
@@ -63,3 +48,40 @@ type KeyboardButtonCallback struct {
 type KeyboardButtonRequest struct {
 	Action string `json:"action"`
 }
+
+type KeyboardRowGeneric[B any] struct {
+	Buttons []B `json:"buttons"`
+}
+
+type KeyboardMarkupGeneric[B any] struct {
+	Rows []KeyboardRowGeneric[B] `json:"rows"`
+}
+
+type KeyboardRowWithSectionGeneric[B any] struct {
+	Section string `json:"section"`
+	Buttons []B    `json:"buttons"`
+}
+
+type KeyboardListReplyGeneric[B any] struct {
+	MainButtonTitle string                             `json:"mainButtonTitle"`
+	Sections        []KeyboardRowWithSectionGeneric[B] `json:"sections"`
+}
+
+type KeyboardMarkup = KeyboardMarkupGeneric[KeyboardButton]
+type KeyboardListReply = KeyboardListReplyGeneric[KeyboardButton]
+
+type InteractiveGeneric[B any] struct {
+	Documents *Documents                   `json:"documents,omitempty"`
+	Images    *Images                      `json:"images,omitempty"`
+	SingleUse bool                         `json:"singleUse"`
+	Markup    *KeyboardMarkupGeneric[B]    `json:"markup,omitempty"`
+	ListReply *KeyboardListReplyGeneric[B] `json:"listReply,omitempty"`
+}
+
+type SendInteractiveRequestGeneric[B any] struct {
+	Interactive InteractiveGeneric[B] `json:"interactive"`
+	Body        string                `json:"body"`
+	Metadata    map[string]any        `json:"metadata"`
+}
+
+type SendInteractiveRequest = SendInteractiveRequestGeneric[KeyboardButton]

--- a/model/variables.go
+++ b/model/variables.go
@@ -2,12 +2,13 @@ package model
 
 import (
 	"regexp"
+	"slices"
 	"strings"
 )
 
 var compileVar *regexp.Regexp
 
-type Variables map[string]interface{}
+type Variables map[string]any
 
 type ParseOption uint
 
@@ -49,11 +50,5 @@ func ParseText(c Connection, text string, ops ...ParseOption) string {
 }
 
 func hasOption(o ParseOption, ops ...ParseOption) bool {
-	for _, v := range ops {
-		if o == v {
-			return true
-		}
-	}
-
-	return false
+	return slices.Contains(ops, o)
 }

--- a/mq/layered_mq.go
+++ b/mq/layered_mq.go
@@ -38,7 +38,7 @@ func (l *LayeredMQ) ConsumeExec() <-chan model.ChannelExec {
 	return l.MQLayer.ConsumeExec()
 }
 
-func (l *LayeredMQ) ConsumeIM() <-chan model.MessageWrapper {
+func (l *LayeredMQ) ConsumeIM() <-chan model.IMEventWrapper {
 	return l.MQLayer.ConsumeIM()
 }
 

--- a/mq/mq.go
+++ b/mq/mq.go
@@ -4,16 +4,16 @@ import (
 	"github.com/webitel/flow_manager/model"
 )
 
+type QueueEvent any
+
 type MQ interface {
 	SendJSON(exchange, key string, data []byte) *model.AppError
 	Close()
 
 	ConsumeCallEvent() <-chan model.CallActionData
 	ConsumeExec() <-chan model.ChannelExec
-	ConsumeIM() <-chan model.MessageWrapper
+	ConsumeIM() <-chan model.IMEventWrapper
 	ConsumeCCEvents() <-chan model.CCQueueEvent
 
 	QueueEvent() QueueEvent
 }
-
-type QueueEvent any

--- a/mq/rabbit/client.go
+++ b/mq/rabbit/client.go
@@ -48,7 +48,7 @@ type AMQP struct {
 	stopping           bool
 	callEvent          chan model.CallActionData
 	execEvent          chan model.ChannelExec
-	imEvents           chan model.MessageWrapper
+	imEvents           chan model.IMEventWrapper
 	ccEvents           chan model.CCQueueEvent
 	queueEvent         mq.QueueEvent
 	sync.RWMutex
@@ -59,7 +59,7 @@ func NewRabbitMQ(settings model.MQSettings, nodeName string) mq.LayeredMQLayer {
 		settings:  &settings,
 		callEvent: make(chan model.CallActionData, CallChanBufferCount),
 		execEvent: make(chan model.ChannelExec, CallChanBufferCount),
-		imEvents:  make(chan model.MessageWrapper, CallChanBufferCount),
+		imEvents:  make(chan model.IMEventWrapper, CallChanBufferCount),
 		ccEvents:  make(chan model.CCQueueEvent, CallChanBufferCount),
 		nodeName:  nodeName,
 	}
@@ -77,7 +77,7 @@ func (a *AMQP) initConnection() {
 	var err error
 
 	if a.connectionAttempts >= MAX_ATTEMPTS_CONNECT {
-		wlog.Critical(fmt.Sprintf("Failed to open AMQP connection..."))
+		wlog.Critical("Failed to open AMQP connection...")
 		time.Sleep(time.Second)
 		os.Exit(1)
 	}
@@ -169,7 +169,7 @@ func (a *AMQP) initQueues() {
 	a.subscribeCC()
 
 	if a.settings.UseIM {
-		a.subscribeIM()
+		go a.subscribeIM()
 	}
 }
 
@@ -265,74 +265,6 @@ func (a *AMQP) subscribeExec() {
 			default:
 				wlog.Warn(fmt.Sprintf("unable to parse event, not found exchange %s", m.Exchange))
 			}
-			m.Ack(false)
-		}
-
-		if !a.stopping {
-			a.initConnection()
-		}
-	}()
-}
-
-func (a *AMQP) subscribeIM() {
-	imQueueName := fmt.Sprintf("%s.%s.any", model.IMQueueNamePrefix, model.NewId()[0:8])
-
-	imQueue, err := a.channel.QueueDeclare(
-		imQueueName,
-		true,
-		false,
-		false,
-		true,
-		amqp.Table{
-			"x-queue-type": "quorum",
-			"x-expires":    10000, // delete after 10s
-		},
-	)
-	if err != nil {
-		wlog.Critical(fmt.Sprintf("Failed to declare AMQP queue %v to err:%v", imQueueName, err.Error()))
-		time.Sleep(time.Second)
-		os.Exit(EXIT_DECLARE_QUEUE)
-	} else {
-		wlog.Debug(fmt.Sprintf("Success declare queue %v connected consumers %v", imQueue.Name, imQueue.Consumers))
-	}
-
-	if err = a.channel.QueueBind(imQueue.Name, "#", model.IMExchange, true, nil); err != nil {
-		wlog.Critical(fmt.Sprintf("Error binding queue %s to %s: %s", imQueue.Name, model.IMExchange, err.Error()))
-		time.Sleep(time.Second)
-		os.Exit(EXIT_BIND)
-	}
-
-	msgs, err := a.channel.Consume(
-		imQueue.Name,
-		"",
-		false,
-		false,
-		false,
-		false,
-		nil,
-	)
-	if err != nil {
-		wlog.Critical(fmt.Sprintf("Error create consume for queue %s: %s", imQueue.Name, err.Error()))
-		time.Sleep(time.Second)
-		os.Exit(EXIT_BIND)
-	}
-
-	go func() {
-		for m := range msgs {
-			switch m.Exchange {
-			case model.IMExchange:
-				var data model.MessageWrapper
-				json.Unmarshal(m.Body, &data)
-				if data.Echo {
-					println("skip echo")
-					continue
-				}
-				a.imEvents <- data
-
-			default:
-				wlog.Warn(fmt.Sprintf("unable to parse event, not found exchange %s", m.Exchange))
-			}
-
 			m.Ack(false)
 		}
 
@@ -542,7 +474,7 @@ func (a *AMQP) ConsumeExec() <-chan model.ChannelExec {
 	return a.execEvent
 }
 
-func (a *AMQP) ConsumeIM() <-chan model.MessageWrapper {
+func (a *AMQP) ConsumeIM() <-chan model.IMEventWrapper {
 	return a.imEvents
 }
 

--- a/mq/rabbit/client_im.go
+++ b/mq/rabbit/client_im.go
@@ -1,0 +1,112 @@
+package rabbit
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strings"
+
+	amqp "github.com/rabbitmq/amqp091-go"
+	"github.com/webitel/flow_manager/model"
+	"github.com/webitel/wlog"
+)
+
+func (a *AMQP) subscribeIM() {
+	imQueueName := fmt.Sprintf("%s.%s.any", model.IMQueueNamePrefix, model.NewId()[0:8])
+	queueArgs := amqp.Table{"x-queue-type": "quorum", "x-expires": 10000}
+
+	imQueue, err := a.channel.QueueDeclare(imQueueName, true, false, false, true, queueArgs)
+	if err != nil {
+		wlog.Critical("[AQMP] declare IM queue", wlog.String("queue", imQueueName), wlog.Err(err))
+		panic("failed to declare AMQP IM queue")
+	}
+
+	wlog.Debug("[AMQP] successfully declared IM AMQP queue", wlog.String("queue", imQueue.Name), wlog.Int("consumers", imQueue.Consumers))
+
+	if err = a.channel.QueueBind(imQueue.Name, "#", model.IMExchange, true, nil); err != nil {
+		wlog.Critical("[AMQP] during binding IM queue to delivery exchange", wlog.String("queue", imQueue.Name), wlog.String("exchange", model.IMExchange), wlog.Err(err))
+		panic("error during binding IM queue to delivery exchange")
+	}
+
+	msgs, err := a.channel.Consume(imQueue.Name, "", false, false, false, false, nil)
+	if err != nil {
+		wlog.Critical("[AMQP] during starting consuming IM messages", wlog.String("queue", imQueue.Name), wlog.String("exchange", model.IMExchange), wlog.Err(err))
+		panic("error during starting consuming IM messages")
+	}
+
+	for m := range msgs {
+		if m.Exchange != model.IMExchange {
+			wlog.Warn("[AMQP] received message from unexpected exchange", wlog.String("received_exchange", m.Exchange), wlog.String("expected_exchange", model.IMExchange))
+
+			continue
+		}
+
+		if err := a.processReceivedIMEvent(m); err != nil {
+			wlog.Error("[AMQP] processing received IM event", wlog.String("received_rk", m.RoutingKey), wlog.Err(err))
+		}
+
+		m.Ack(false)
+	}
+
+	if !a.stopping {
+		a.initConnection()
+	}
+}
+
+func (a *AMQP) processReceivedIMEvent(event amqp.Delivery) error {
+	rk := event.RoutingKey
+
+	if strings.HasPrefix(rk, "im_delivery.v1.") && strings.HasSuffix(rk, ".message.created") {
+		return a.handleIMMessageEvent(event)
+	}
+
+	if strings.HasPrefix(rk, "im_delivery.v1.") && strings.HasSuffix(rk, ".interactive_callback.reacted") {
+		return a.handleIMInteractiveCallbackEvent(event)
+	}
+
+	return nil
+}
+
+func (a *AMQP) handleIMMessageEvent(event amqp.Delivery) error {
+	var messageWrapper model.MessageWrapper[model.Message]
+	if err := json.Unmarshal(event.Body, &messageWrapper); err != nil {
+		return model.NewAppError(
+			"processReceivedIMEvent",
+			"rabbit.client.process_received_im_event.unmarshaling_body",
+			nil,
+			err.Error(),
+			http.StatusBadRequest,
+		)
+	}
+
+	if messageWrapper.Echo {
+		wlog.Info("skipping echo IM event", wlog.String("thread_id", messageWrapper.Message.ThreadID), wlog.String("message_id", messageWrapper.Message.ID))
+
+		return nil
+	}
+
+	messageWrapper.Type = model.IMEventTypeMessage
+
+	a.imEvents <- messageWrapper
+
+	return nil
+}
+
+func (a *AMQP) handleIMInteractiveCallbackEvent(event amqp.Delivery) error {
+	var interactiveCallbackWrapper model.MessageWrapper[model.InteractiveCallback]
+	if err := json.Unmarshal(event.Body, &interactiveCallbackWrapper); err != nil {
+		return model.NewAppError(
+			"handleIMInteractiveCallbackEvent",
+			"rabbit.client_im.handle_im_interactive_callback_event.unmarshal_event",
+			nil,
+			err.Error(),
+			http.StatusBadRequest,
+		)
+	}
+
+	interactiveCallbackWrapper.Type = model.IMEventTypeCallback
+
+	a.imEvents <- interactiveCallbackWrapper
+
+	return nil
+}

--- a/providers/im/connection.go
+++ b/providers/im/connection.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 	"maps"
 	"net/http"
-	"slices"
 	"strconv"
 	"strings"
 	"sync"
@@ -23,49 +22,50 @@ import (
 	"github.com/webitel/flow_manager/model"
 )
 
-var ErrWaitMessageTimeout = model.NewAppError("Dialog.WaitMessage", "dialog.timeout.msg", nil, "Timeout", http.StatusInternalServerError)
+var ErrWaitMessageTimeout = model.NewAppError("Dialog.WaitMessage", "dialog.timeout.msg", nil, "Timeout", http.StatusRequestTimeout)
 
 var _ model.IMDialog = (*Connection)(nil)
 
 type Connection struct {
-	id        string
-	threadId  string
-	ctx       context.Context
-	domainId  int64
-	schemaId  int
-	srv       *server
-	variables map[string]string
-	msg       model.Message
 	sync.RWMutex
+
+	id              string
+	threadId        string
+	ctx             context.Context
+	domainId        int64
+	schemaId        int
+	srv             *server
+	variables       map[string]string
+	msg             model.Message
 	lastMsg         model.Message
 	from            model.ImEndpoint
 	to              model.ImEndpoint
 	log             *wlog.Logger
-	waitMsgChan     chan model.MessageWrapper
+	waitMsgChan     chan model.IMEventWrapper
 	hdrs            metadata.MD
 	queueKey        *model.InQueueKey
 	exportVariables []string
-	messages        []model.MessageWrapper
+	messages        []model.IMEventWrapper
 	info            model.ThreadInfo
 }
 
-func newConnection(s *server, id string, to model.ImEndpoint, msg model.MessageWrapper) *Connection {
+func newConnection(s *server, id string, to model.ImEndpoint, msg model.IMEventWrapper) *Connection {
 	schemaId, _ := strconv.Atoi(to.Sub)
 
 	conn := &Connection{
 		id:       id,
-		threadId: msg.Message.ThreadID,
+		threadId: msg.GetPayload().GetThreadID(),
 		srv:      s,
-		from:     msg.Message.From,
+		from:     msg.GetPayload().Sender(),
 		to:       to,
-		lastMsg:  msg.Message,
+		lastMsg:  msg.GetPayload().Message(),
 		hdrs: metadata.New(map[string]string{
 			"x-webitel-type":   "schema",
-			"x-webitel-schema": fmt.Sprintf("%d.%d", msg.DomainID, schemaId),
+			"x-webitel-schema": fmt.Sprintf("%d.%d", msg.GetDomainID(), schemaId),
 		}),
-		msg:       msg.Message,
+		msg:       msg.GetPayload().Message(),
 		ctx:       context.Background(),
-		domainId:  msg.DomainID,
+		domainId:  msg.GetDomainID(),
 		variables: toVariables(nil), // todo
 		schemaId:  schemaId,
 		RWMutex:   sync.RWMutex{},
@@ -73,8 +73,8 @@ func newConnection(s *server, id string, to model.ImEndpoint, msg model.MessageW
 			wlog.Namespace("context"),
 			wlog.String("scope", "im"),
 			wlog.String("id", id),
-			wlog.String("thread_id", msg.Message.ThreadID),
-			wlog.Int64("domain_id", msg.DomainID),
+			wlog.String("thread_id", msg.GetPayload().GetThreadID()),
+			wlog.Int64("domain_id", msg.GetDomainID()),
 			wlog.Int("schema_id", schemaId),
 		),
 	}
@@ -98,28 +98,78 @@ func (c *Connection) setupVariables() {
 	c.msg.Description = info.Description
 	raw, _ := json.Marshal(c.msg)
 	c.variables["thread"] = string(raw)
-	for k, v := range info.Variables {
-		c.variables[k] = v
-	}
+	maps.Copy(c.variables, info.Variables)
 	c.info = info
 }
 
-func (c *Connection) OnMessage(msg model.MessageWrapper) {
-	if msg.Message.From.Sub == c.to.Sub {
-		c.log.Debug("message from sub changed")
+func (c *Connection) processLastMessage(lastMessage model.IMEventWrapper) {
+	if lastMessage.GetType() != model.IMEventTypeMessage {
 		return
 	}
 
 	c.Lock()
-	c.messages = append(c.messages, msg)
-	ch := c.waitMsgChan
-	c.lastMsg = msg.Message
-	c.Unlock()
-	if ch != nil { // todo skip flow messages
-		ch <- msg
+	defer c.Unlock()
+
+	c.messages = append(c.messages, lastMessage)
+	c.lastMsg = lastMessage.GetPayload().Message()
+}
+
+func (c *Connection) processLastInteractiveCallback(callback model.IMEventWrapper) {
+	if callback.GetType() != model.IMEventTypeCallback {
 		return
 	}
-	c.log.Debug("message "+msg.Message.Text, wlog.String("thread_id", msg.Message.ThreadID))
+
+	assertedCallback, ok := callback.GetPayload().(model.InteractiveCallback)
+	if !ok {
+		c.log.Warn("unsuccessfull assert from wrapper to callback")
+		return
+	}
+
+	serializedCallback, err := json.Marshal(assertedCallback)
+	if err != nil {
+		c.log.Error("serializing interactive callback for variable setting", wlog.Err(err))
+		return
+	}
+
+	c.Lock()
+	c.variables["clicked_button"] = string(serializedCallback)
+	c.Unlock()
+}
+
+func (c *Connection) pushMessageToWaitMessageChan(message model.IMEventWrapper) {
+	if message.GetPayload().Message().Sender().Issuer == "bot" {
+		return
+	}
+
+	c.RLock()
+	ch := c.waitMsgChan
+	c.RUnlock()
+
+	if ch != nil {
+		ch <- message
+	}
+}
+
+func (c *Connection) OnMessage(msg model.IMEventWrapper) {
+	log := c.log.With(
+		wlog.String("operation", "OnMessage"),
+		wlog.String("from_sub", msg.GetPayload().Sender().Sub),
+		wlog.String("to_sub", c.to.Sub),
+		wlog.String("thread_id", msg.GetPayload().GetThreadID()),
+		wlog.String("message_id", msg.GetPayload().MessageID()),
+		wlog.Int64("domain_id", msg.GetDomainID()),
+	)
+
+	if msg.GetPayload().Sender().Sub == c.to.Sub {
+		log.Debug("message from sub changed")
+		return
+	}
+
+	c.processLastMessage(msg)
+	c.processLastInteractiveCallback(msg)
+	c.pushMessageToWaitMessageChan(msg)
+
+	log.Debug("processed on message event")
 }
 
 func (c *Connection) From() model.ImEndpoint {
@@ -138,7 +188,7 @@ func (c *Connection) LastMessage() model.Message {
 	return c.lastMsg
 }
 
-func (c *Connection) setStateWaitMessage(ch chan model.MessageWrapper) error {
+func (c *Connection) setStateWaitMessage(ch chan model.IMEventWrapper) error {
 	c.Lock()
 	defer c.Unlock()
 
@@ -156,7 +206,6 @@ func (c *Connection) SendMessage(ctx context.Context, msg model.ChatMessageOutbo
 	if msg.File != nil {
 		f := msg.File
 		docs = append(docs, &p.ImageInput{
-			// Id:       strconv.Itoa(f.Id),
 			Name:     f.Name,
 			Link:     f.Url,
 			MimeType: f.MimeType,
@@ -178,7 +227,7 @@ func (c *Connection) SendMessage(ctx context.Context, msg model.ChatMessageOutbo
 		},
 	})
 	if err != nil {
-		return model.CallResponseError, model.NewAppError("SendMessage", "conv.msg", nil, err.Error(), http.StatusInternalServerError)
+		return model.CallResponseError, model.NewAppError("SendMessage", "conv.msg", nil, err.Error(), model.ExtractHTPPStatusCodeFromGRPC(err))
 	}
 
 	return model.CallResponseOK, nil
@@ -375,21 +424,6 @@ func (c *Connection) UnSet(_ context.Context, varKeys []string) (model.Response,
 	return model.CallResponseOK, nil
 }
 
-func (c *Connection) LastMessages(limit int) []model.ChatMessage {
-	c.RLock()
-	msgs := slices.Clone(c.messages)
-	c.RUnlock()
-
-	if limit > 0 && len(msgs) > limit {
-		msgs = msgs[len(msgs)-limit:]
-	}
-	result := make([]model.ChatMessage, 0, len(msgs))
-	for _, m := range msgs {
-		result = append(result, model.ChatMessage{Text: m.Message.Text})
-	}
-	return result
-}
-
 func (c *Connection) GetQueueKey() *model.InQueueKey {
 	c.log.Info("GetQueueKey")
 	c.RLock()
@@ -429,16 +463,13 @@ func (c *Connection) ReceiveMessage(ctx context.Context, name string, timeout, m
 	}
 
 	if messageTimeout > 0 {
-		var m []model.MessageWrapper
+		var m []model.IMEventWrapper
 		for err == nil {
 			m, err = c.receive(ctx, messageTimeout)
 			msgs = append(msgs, m...)
 		}
 	}
-	//if len(msgs) > 0 && name != "" {
-	//	c.storeMessages[name], _ = json.Marshal(msgs[0])
-	//}
-	//c.saveMessages(msgs...)
+
 	return messageToText(msgs...), nil
 }
 
@@ -471,7 +502,7 @@ func (connection *Connection) SendInteractive(ctx context.Context, interactive m
 	return model.CallResponseOK, nil
 }
 
-func convertToProtoInteractive(src *model.Interactive) *p.Interactive {
+func convertToProtoInteractive(src *model.InteractiveGeneric[model.KeyboardButton]) *p.Interactive {
 	if src == nil {
 		return nil
 	}
@@ -605,15 +636,15 @@ func (c *Connection) Stop(err error) {
 	c.srv.stopConnection(c)
 }
 
-func (c *Connection) receive(ctx context.Context, timeout int) ([]model.MessageWrapper, *model.AppError) {
-	ch := make(chan model.MessageWrapper)
+func (c *Connection) receive(_ context.Context, timeout int) ([]model.IMEventWrapper, *model.AppError) {
+	ch := make(chan model.IMEventWrapper)
 	defer func() {
 		c.setStateWaitMessage(nil)
 	}()
 
 	err := c.setStateWaitMessage(ch)
 	if err != nil {
-		c.log.Warn("Failed to set wait message chan")
+		c.log.Warn("failed to set wait message chan")
 		return nil, model.NewAppError("Conversation.WaitMessage", "conv.timeout.msg", nil, "Timeout", http.StatusInternalServerError)
 	}
 
@@ -623,44 +654,24 @@ func (c *Connection) receive(ctx context.Context, timeout int) ([]model.MessageW
 
 	select {
 	case <-c.Context().Done():
-		c.log.Debug("cancel")
-		return nil, model.NewAppError("Conversation.WaitMessage", "conv.timeout.msg.app_err", nil, "Cancel", http.StatusInternalServerError)
+		c.log.Debug("context cancelled", wlog.Err(c.Context().Err()))
+		return nil, model.NewAppError("Conversation.WaitMessage", "conv.timeout.msg.app_err", nil, c.Context().Err().Error(), http.StatusInternalServerError)
 	case <-t:
-		c.log.Debug("timeout")
+		c.log.Debug("waiting message timeout", wlog.Int("timeout_sec", timeout))
 		return nil, ErrWaitMessageTimeout
 	case msgsProto := <-ch:
 		c.log.Debug(fmt.Sprintf("receive message: %v", msgsProto))
-		return []model.MessageWrapper{msgsProto}, nil
+		return []model.IMEventWrapper{msgsProto}, nil
 	}
 }
 
-func (c *Connection) Type() model.ConnectionType {
-	return model.ConnectionTypeIM
-}
-
-func (c *Connection) Log() *wlog.Logger {
-	return c.log
-}
-
-func (c *Connection) Id() string {
-	return c.id
-}
-
-func (c *Connection) SchemaId() int {
-	return c.schemaId
-}
-
-func (c *Connection) NodeId() string {
-	return ""
-}
-
-func (c *Connection) DomainId() int64 {
-	return c.domainId
-}
-
-func (c *Connection) Context() context.Context {
-	return c.ctx
-}
+func (c *Connection) Type() model.ConnectionType { return model.ConnectionTypeIM }
+func (c *Connection) Log() *wlog.Logger          { return c.log }
+func (c *Connection) Id() string                 { return c.id }
+func (c *Connection) SchemaId() int              { return c.schemaId }
+func (c *Connection) NodeId() string             { return "" }
+func (c *Connection) DomainId() int64            { return c.domainId }
+func (c *Connection) Context() context.Context   { return c.ctx }
 
 func (c *Connection) Get(key string) (string, bool) {
 	c.RLock()
@@ -704,9 +715,7 @@ func (c *Connection) Variables() map[string]string {
 	return maps.Clone(c.variables)
 }
 
-func (c *Connection) TreadInfo() model.ThreadInfo {
-	return c.info
-}
+func (c *Connection) TreadInfo() model.ThreadInfo { return c.info }
 
 func (c *Connection) treadInfo(ctx context.Context) (model.ThreadInfo, *model.AppError) {
 	var info model.ThreadInfo
@@ -720,7 +729,7 @@ func (c *Connection) treadInfo(ctx context.Context) (model.ThreadInfo, *model.Ap
 	}
 
 	if len(result.Items) == 0 {
-		return info, model.NewAppError("Connection.TreadInfo", "conv.thread_info.not_found", nil, err.Error(), http.StatusNotFound)
+		return info, model.NewAppError("Connection.TreadInfo", "conv.thread_info.not_found", nil, "result thread info set contains zero records", http.StatusNotFound)
 	}
 
 	infoResult := result.Items[0]
@@ -767,11 +776,11 @@ func toVariables(in map[string]json.RawMessage) map[string]string {
 	return vars
 }
 
-func messageToText(messages ...model.MessageWrapper) []string {
+func messageToText(messages ...model.IMEventWrapper) []string {
 	msgs := make([]string, 0, len(messages))
 
 	for _, m := range messages {
-		msgs = append(msgs, m.Message.Text)
+		msgs = append(msgs, m.GetPayload().Message().Text)
 	}
 
 	return msgs

--- a/providers/im/server.go
+++ b/providers/im/server.go
@@ -2,7 +2,6 @@ package im
 
 import (
 	"crypto/tls"
-	"fmt"
 	"sync"
 
 	"github.com/webitel/engine/pkg/discovery"
@@ -19,7 +18,7 @@ type SessionStore interface {
 
 type server struct {
 	id              string
-	receiver        <-chan model.MessageWrapper
+	receiver        <-chan model.IMEventWrapper
 	consume         chan model.Connection
 	didFinishListen chan struct{}
 	stopped         chan struct{}
@@ -30,7 +29,7 @@ type server struct {
 	sessionStore    SessionStore
 }
 
-func NewServer(id, consulAddr string, receiver <-chan model.MessageWrapper, log *wlog.Logger, t *tls.Config, store SessionStore) model.Server {
+func NewServer(id, consulAddr string, receiver <-chan model.IMEventWrapper, log *wlog.Logger, t *tls.Config, store SessionStore) model.Server {
 	return &server{
 		id:              id,
 		receiver:        receiver,
@@ -44,9 +43,7 @@ func NewServer(id, consulAddr string, receiver <-chan model.MessageWrapper, log 
 	}
 }
 
-func (s *server) Name() string {
-	return "IM"
-}
+func (s *server) Name() string { return "IM" }
 
 func (s *server) Start() *model.AppError {
 	s.startOnce.Do(func() {
@@ -98,25 +95,28 @@ func (s *server) Cluster(discovery discovery.ServiceDiscovery) *model.AppError {
 
 func (s *server) listen() {
 	defer func() {
-		wlog.Debug("stop listen channel server...")
+		wlog.Debug("stop listen IM channel server...")
 		close(s.stopped)
 	}()
 
-	wlog.Debug("start listen channel")
+	wlog.Debug("start listen IM channel")
 
 	for {
 		select {
 		case <-s.didFinishListen:
 			return
 		case c, ok := <-s.receiver:
-			if ok {
-				if c.Message.ThreadID == "" {
-					s.log.Warn(fmt.Sprintf("received message with empty thread id %v", c))
-					continue
-				}
-				if err := s.nodeMessage(c); err != nil {
-					s.log.Warn(fmt.Sprintf("failed to handle message %v: %v", c, err))
-				}
+			if !ok {
+				continue //? switch to return or break to skip infinity loop?
+			}
+
+			if c.GetPayload().GetThreadID() == "" {
+				s.log.Warn("received message with empty thread ID", wlog.String("message_id", c.GetPayload().MessageID()))
+				continue
+			}
+
+			if err := s.nodeMessage(c); err != nil {
+				s.log.Error("handling message", wlog.String("message_id", c.GetPayload().MessageID()), wlog.Err(err))
 			}
 		}
 	}
@@ -130,43 +130,44 @@ func (s *server) stopConnection(c *Connection) {
 	}
 }
 
-func (s *server) nodeMessage(msg model.MessageWrapper) error {
-	if msg.Message.From.Issuer == "bot" {
+const IMUserTypeBot string = "bot"
+
+func (s *server) nodeMessage(msg model.IMEventWrapper) error {
+	if msg.GetPayload().Sender().Issuer == IMUserTypeBot {
 		return nil
 	}
 
-	for _, endpoint := range msg.Message.To {
-		if endpoint.Issuer != "bot" {
+	for _, endpoint := range msg.GetPayload().Receivers() {
+		if endpoint.Issuer != IMUserTypeBot {
 			continue
 		}
 
-		id := fmt.Sprintf("%s.%s", msg.Message.ThreadID, endpoint.Sub)
-		conn, ok := s.connectionStore.Get(id)
-		if ok {
+		compositeSessionID := msg.GetPayload().GetThreadID() + "." + endpoint.Sub
+
+		if conn, ok := s.connectionStore.Get(compositeSessionID); ok {
 			conn.OnMessage(msg)
 			continue
-
 		}
 
-		seq, err := s.sessionStore.Touch(id, s.id)
+		seq, err := s.sessionStore.Touch(compositeSessionID, s.id)
 		if err != nil {
 			return err
 		}
+
 		if seq == nil {
 			return nil
 		}
 
 		if *seq > 1 {
-			s.log.Warn(fmt.Sprintf("received message with seq thread id %v", *seq))
+			s.log.Warn("received message with sequance thread ID", wlog.Int("sequance", *seq))
 		}
 
-		dialog := newConnection(s, id, endpoint, msg)
+		dialog := newConnection(s, compositeSessionID, endpoint, msg)
 		dialog.setupVariables()
 
 		s.connectionStore.Add(dialog)
-		dialog.log.Debug("start dialog " + id)
+		dialog.log.Debug("start dialog " + compositeSessionID)
 		s.consume <- dialog
-
 	}
 
 	return nil

--- a/providers/im/store.go
+++ b/providers/im/store.go
@@ -2,9 +2,10 @@ package im
 
 import (
 	"errors"
+	"time"
+
 	"github.com/hashicorp/golang-lru/v2/expirable"
 	"github.com/webitel/wlog"
-	"time"
 )
 
 const (
@@ -29,12 +30,13 @@ func NewConnectionStore(log *wlog.Logger) *ConnectionStore {
 }
 
 func (s *ConnectionStore) Get(id string) (*Connection, bool) {
-	conn, ok := s.conns.Get(id)
-	if ok {
+	if conn, ok := s.conns.Get(id); ok {
 		s.log.Debug("connection cache hit", wlog.String("id", id))
 		return conn, true
 	}
+
 	s.log.Debug("connection cache miss", wlog.String("id", id))
+
 	return nil, false
 }
 
@@ -44,6 +46,6 @@ func (s *ConnectionStore) Add(conn *Connection) {
 }
 
 func (s *ConnectionStore) Delete(conn *Connection) {
-	s.log.Debug("delete connection to cache", wlog.String("id", conn.Id()))
+	s.log.Debug("delete connection from cache", wlog.String("id", conn.Id()))
 	s.conns.Remove(conn.Id())
 }

--- a/routes/im/applications.go
+++ b/routes/im/applications.go
@@ -39,9 +39,6 @@ func ApplicationsHandlers(r *Router) flow.ApplicationHandlers {
 	apps["stt"] = &flow.Application{
 		Handler: chatHandlerMiddleware(r.sendSTT),
 	}
-	apps["joinQueue"] = &flow.Application{
-		Handler: chatHandlerMiddleware(r.joinQueue),
-	}
 	apps["cancelQueue"] = &flow.Application{
 		Handler: chatHandlerMiddleware(r.cancelQueue),
 	}
@@ -58,6 +55,7 @@ func ApplicationsHandlers(r *Router) flow.ApplicationHandlers {
 		Handler: chatHandlerMiddleware(r.joinQueue),
 	}
 	apps["sendInteractive"] = &flow.Application{Handler: chatHandlerMiddleware(r.SendInteractive)}
+	apps["interactiveMenu"] = &flow.Application{Handler: chatHandlerMiddleware(r.MenuWithReceive)}
 
 	return apps
 }

--- a/routes/im/menu.go
+++ b/routes/im/menu.go
@@ -2,9 +2,13 @@ package im
 
 import (
 	"context"
+	"encoding/json"
+	"net/http"
+	"strings"
 
 	"github.com/webitel/flow_manager/flow"
 	"github.com/webitel/flow_manager/model"
+	"github.com/webitel/wlog"
 )
 
 func (r *Router) Menu(ctx context.Context, scope *flow.Flow, conv Dialog, args any) (model.Response, *model.AppError) {
@@ -22,4 +26,158 @@ func (r *Router) Menu(ctx context.Context, scope *flow.Flow, conv Dialog, args a
 	}
 
 	return conv.SendMenu(ctx, &argv)
+}
+
+type MenuButton struct {
+	model.KeyboardButton `json:",inline"`
+
+	NextFlow []any `json:"nextFlow,omitempty"`
+}
+
+type MenuArgs struct {
+	model.SendInteractiveRequestGeneric[MenuButton] `json:",inline"`
+
+	Timeout        int    `json:"timeout"`
+	MessageTimeout int    `json:"messageTimeout"`
+	Set            string `json:"set"`
+	Default        []any  `json:"default"`
+}
+
+func ConvertMenuRequestToStandard(menuReq model.SendInteractiveRequestGeneric[MenuButton]) model.SendInteractiveRequest {
+	var standardMarkup *model.KeyboardMarkup
+	var standardListReply *model.KeyboardListReply
+
+	if menuReq.Interactive.Markup != nil {
+		standardRows := make([]model.KeyboardRowGeneric[model.KeyboardButton], len(menuReq.Interactive.Markup.Rows))
+		for i, menuRow := range menuReq.Interactive.Markup.Rows {
+			standardButtons := make([]model.KeyboardButton, len(menuRow.Buttons))
+			for j, menuBtn := range menuRow.Buttons {
+				standardButtons[j] = menuBtn.KeyboardButton
+			}
+			standardRows[i] = model.KeyboardRowGeneric[model.KeyboardButton]{
+				Buttons: standardButtons,
+			}
+		}
+		standardMarkup = &model.KeyboardMarkup{Rows: standardRows}
+	}
+
+	if menuReq.Interactive.ListReply != nil {
+		standardSections := make([]model.KeyboardRowWithSectionGeneric[model.KeyboardButton], len(menuReq.Interactive.ListReply.Sections))
+		for i, menuSection := range menuReq.Interactive.ListReply.Sections {
+			standardButtons := make([]model.KeyboardButton, len(menuSection.Buttons))
+			for j, menuBtn := range menuSection.Buttons {
+				standardButtons[j] = menuBtn.KeyboardButton
+			}
+			standardSections[i] = model.KeyboardRowWithSectionGeneric[model.KeyboardButton]{
+				Section: menuSection.Section,
+				Buttons: standardButtons,
+			}
+		}
+		standardListReply = &model.KeyboardListReply{
+			MainButtonTitle: menuReq.Interactive.ListReply.MainButtonTitle,
+			Sections:        standardSections,
+		}
+	}
+
+	return model.SendInteractiveRequest{
+		Body:     menuReq.Body,
+		Metadata: menuReq.Metadata,
+		Interactive: model.InteractiveGeneric[model.KeyboardButton]{
+			Documents: menuReq.Interactive.Documents,
+			Images:    menuReq.Interactive.Images,
+			SingleUse: menuReq.Interactive.SingleUse,
+			Markup:    standardMarkup,
+			ListReply: standardListReply,
+		},
+	}
+}
+
+func NewReceiveMenuArgs(properties any) (*MenuArgs, *model.AppError) {
+	bytes, err := json.Marshal(properties)
+	if err != nil {
+		return nil, model.NewAppError("IM.NewReceiveMenuArgs", "flow.menu.marshal_err", nil, err.Error(), http.StatusInternalServerError)
+	}
+
+	var args MenuArgs
+	if err := json.Unmarshal(bytes, &args); err != nil {
+		return nil, model.NewAppError("IM.NewReceiveMenuArgs", "flow.menu.unmarshal_err", nil, err.Error(), http.StatusBadRequest)
+	}
+
+	return &args, nil
+}
+
+func (r *Router) MenuWithReceive(ctx context.Context, scope *flow.Flow, conv Dialog, args any) (model.Response, *model.AppError) {
+	req, err := NewReceiveMenuArgs(args)
+	if err != nil {
+		return nil, err
+	}
+
+	if _, err := conv.SendInteractive(ctx, ConvertMenuRequestToStandard(req.SendInteractiveRequestGeneric)); err != nil {
+		return nil, err
+	}
+
+	events, appErr := conv.ReceiveMessage(ctx, req.Set, req.Timeout, req.MessageTimeout)
+	if appErr != nil {
+		return nil, appErr
+	}
+
+	if len(events) == 0 {
+		return nil, model.NewAppError("Flow.MenuWithReceive", "flow.menu.empty_event", nil, "no event received", http.StatusInternalServerError)
+	}
+
+	if _, err := conv.Set(ctx, model.Variables{req.Set: strings.Join(events, " ")}); err != nil {
+		wlog.Error("setting received message as variable", wlog.String("conversation_id", conv.Id()), wlog.Err(err))
+	}
+
+	clickedButtonID := events[0]
+	var clickedButton *MenuButton
+
+	if req.Interactive.Markup != nil {
+		for i := range req.Interactive.Markup.Rows {
+			for j := range req.Interactive.Markup.Rows[i].Buttons {
+				if req.Interactive.Markup.Rows[i].Buttons[j].ID == clickedButtonID {
+					clickedButton = &req.Interactive.Markup.Rows[i].Buttons[j]
+					break
+				}
+			}
+			if clickedButton != nil {
+				break
+			}
+		}
+	}
+
+	if clickedButton == nil && req.Interactive.ListReply != nil {
+		for i := range req.Interactive.ListReply.Sections {
+			for j := range req.Interactive.ListReply.Sections[i].Buttons {
+				if req.Interactive.ListReply.Sections[i].Buttons[j].ID == clickedButtonID {
+					clickedButton = &req.Interactive.ListReply.Sections[i].Buttons[j]
+					break
+				}
+			}
+			if clickedButton != nil {
+				break
+			}
+		}
+	}
+
+	if clickedButton != nil && len(clickedButton.NextFlow) > 0 {
+		forkedBranch := scope.Fork(clickedButtonID, flow.ArrInterfaceToArrayApplication(clickedButton.NextFlow))
+		flow.Route(ctx, forkedBranch, r)
+
+		wlog.Debug("menu routing set to button node", wlog.String("conversation_id", conv.Id()), wlog.String("clicked_button_id", clickedButtonID))
+		scope.SetCancel()
+		return model.CallResponseOK, nil
+	}
+
+	if req.Default != nil {
+		forkedBranch := scope.Fork(clickedButtonID, flow.ArrInterfaceToArrayApplication(req.Default))
+		flow.Route(ctx, forkedBranch, r)
+
+		wlog.Debug("menu routing set to default node", wlog.String("conversation_id", conv.Id()))
+		scope.SetCancel()
+		return model.CallResponseOK, nil
+	}
+
+	wlog.Debug("menu button has no explicit next node, continuing standard flow", wlog.String("conversation_id", conv.Id()), wlog.String("clicked_button_id", clickedButtonID))
+	return model.CallResponseOK, nil
 }


### PR DESCRIPTION
- add new application `interactiveMenu`
- add AMQP segregation for IM core events [messages, callbacks]
- add using of structured logger functionality
- add `interactiveCallback` handler
- implement interactive menu functionality with embeded routes and waiting for receive message
- add posibillity for setting up `default` interactive menu route
- add setting `system` varible [`clicked_button`] with JSON for callback data
- add setting variable for received message value into variable with key given as `Set` param