### PR TITLE
fix(systemd): add missing LogsDirectory

### DIFF
--- a/deploy/systemd/webitel-flow-manager.service
+++ b/deploy/systemd/webitel-flow-manager.service
@@ -8,6 +8,7 @@ StartLimitBurst=3
 Type=simple
 User=webitel
 Group=webitel
+LogsDirectory=webitel
 
 EnvironmentFile=/etc/default/webitel-flow-manager
 EnvironmentFile=-/etc/default/webitel-otel


### PR DESCRIPTION
`LogsDirectory=webitel` was dropped from this unit during the earlier hardening merge. Restore it so systemd provisions a writable `/var/log/webitel` for the service (consistent with the other units).

🤖 Generated with [Claude Code](https://claude.com/claude-code)