### PR TITLE
feat(deb): read chat templates from /usr/share/webitel

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -71,7 +71,7 @@ SERVICE_CONN_CLIENT_CERT=
 PRESIGNED_CERT=/opt/storage/key.pem
 RECORD_SAMPLE=0
 DEBUG_IMAP=false
-CHAT_TEMPLATES_PATCH=./message_templates
+CHAT_TEMPLATES_PATCH=/usr/share/webitel/webitel-flow-manager/message-templates
 
 # ---------------------------------------------------------------------------
 # OpenTelemetry  (see .env.otel.example for full reference)


### PR DESCRIPTION
Point `CHAT_TEMPLATES_PATCH` at the packaged `/usr/share/webitel/webitel-flow-manager/message_templates` (read-only) instead of a relative dir.

> Depends on the matching reusable-configs `sync.yml` change (ships the dir under `/usr/share/webitel`). Until that merges + re-syncs, the env points at a not-yet-shipped path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)