### PR TITLE
[WTEL-9715]fix(email): add decoding to utf-8

### DIFF
--- a/app/mail.go
+++ b/app/mail.go
@@ -31,9 +31,9 @@ func (f *FlowManager) SmtpSettings(domainId int64, search *model.SearchEntity) (
 	})
 
 	if err != nil {
-		switch err.(type) {
+		switch err := err.(type) {
 		case *model.AppError:
-			return nil, err.(*model.AppError)
+			return nil, err
 		default:
 			return nil, model.NewAppError("Queue", "mail.smtp.settings.get", nil, err.Error(), http.StatusInternalServerError)
 		}

--- a/model/email.go
+++ b/model/email.go
@@ -58,6 +58,44 @@ type Email struct {
 	Cid         map[string]EmailCid
 }
 
+const MailDirectionInbound string = "inbound"
+
+func (e *Email) AddAttachment(attachment File) *Email {
+	if e == nil {
+		return nil
+	}
+
+	e.Attachments = append(e.Attachments, attachment)
+
+	return e
+}
+
+func (e *Email) SetBody(text, html []byte) *Email {
+	if e == nil {
+		return nil
+	}
+
+	if text != nil {
+		e.Body = text
+	} else {
+		e.Body = html
+	}
+
+	return e
+}
+
+func (e *Email) SetHTMLBody(html []byte) *Email {
+	if e == nil {
+		return nil
+	}
+
+	e.HtmlBody = html
+
+	return e
+}
+
+func (e *Email) AddCID(cid string, fileID int) { e.Cid[cid] = EmailCid(fileID) }
+
 type EmailAction struct {
 	FlowId    int   `json:"flow_id"`
 	AttemptId int64 `json:"attempt_id"`
@@ -118,7 +156,7 @@ func (p *EmailProfile) Tls() bool {
 }
 
 func OAuthConfig(host string, config *OAuth2Config) oauth2.Config {
-	if strings.Index(host, MailGmail+".com") > -1 {
+	if strings.Contains(host, MailGmail+".com") {
 		return oauth2.Config{
 			ClientID:     config.ClientId,
 			ClientSecret: config.ClientSecret,
@@ -131,7 +169,7 @@ func OAuthConfig(host string, config *OAuth2Config) oauth2.Config {
 				"https://mail.google.com/",
 			},
 		}
-	} else if strings.Index(host, "office365") > -1 && config != nil {
+	} else if strings.Contains(host, "office365") && config != nil {
 		return oauth2.Config{
 			ClientID:     config.ClientId,
 			ClientSecret: config.ClientSecret,

--- a/providers/email/connection.go
+++ b/providers/email/connection.go
@@ -4,10 +4,12 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"maps"
 	"strings"
 	"sync"
 
 	"github.com/tidwall/gjson"
+
 	"github.com/webitel/wlog"
 
 	"github.com/webitel/flow_manager/model"
@@ -21,14 +23,15 @@ type PKey struct {
 }
 
 type connection struct {
+	sync.RWMutex
+
 	id        string
 	srv       *MailServer
 	email     *model.Email
 	variables model.Variables
-	ctx       context.Context
+	ctx       context.Context //nolint:containedctx
 	pkey      PKey
-	sync.RWMutex
-	log *wlog.Logger
+	log       *wlog.Logger
 }
 
 func NewConnection(srv *MailServer, pkey PKey, email *model.Email) *connection {
@@ -37,7 +40,7 @@ func NewConnection(srv *MailServer, pkey PKey, email *model.Email) *connection {
 		srv:       srv,
 		pkey:      pkey,
 		email:     email,
-		variables: make(map[string]interface{}),
+		variables: make(map[string]any),
 		ctx:       context.Background(),
 		log: wlog.GlobalLogger().With(
 			wlog.Namespace("context"),
@@ -53,10 +56,12 @@ func NewConnection(srv *MailServer, pkey PKey, email *model.Email) *connection {
 	c.variables["cc"] = strings.Join(email.CC, ",")
 	c.variables["sender"] = strings.Join(email.Sender, ",")
 	c.variables["in_reply_to"] = email.InReplyTo
+
 	c.variables["body"] = string(email.Body)
 	if email.HtmlBody != nil {
 		c.variables["body_html"] = string(email.HtmlBody)
 	}
+
 	c.variables["subject"] = fmt.Sprintf("%v", email.Subject)
 	c.variables["id"] = fmt.Sprintf("%d", email.Id)
 
@@ -86,7 +91,7 @@ func (c *connection) Id() string {
 }
 
 func (c *connection) NodeId() string {
-	//TODO PROFILE NAME
+	// TODO PROFILE NAME
 	return c.id
 }
 
@@ -102,7 +107,9 @@ func (c *connection) Get(name string) (string, bool) {
 			return gjson.GetBytes([]byte(fmt.Sprintf("%v", v)), name[idx+1:]).String(), true
 		}
 	}
+
 	v, ok := c.variables[name]
+
 	return fmt.Sprintf("%v", v), ok
 }
 
@@ -113,11 +120,10 @@ func (c *connection) GetProfile() (*Profile, *model.AppError) {
 func (c *connection) Set(ctx context.Context, vars model.Variables) (model.Response, *model.AppError) {
 	c.Lock()
 	defer c.Unlock()
-	for k, v := range vars {
-		c.variables[k] = v
-	}
 
-	return model.CallResponseOK, nil //TODO
+	maps.Copy(c.variables, vars)
+
+	return model.CallResponseOK, nil // TODO
 }
 
 func (c *connection) ParseText(text string, ops ...model.ParseOption) string {

--- a/providers/email/control.go
+++ b/providers/email/control.go
@@ -4,12 +4,13 @@ import "github.com/webitel/flow_manager/model"
 
 func (c *connection) Reply(text string) (*model.Email, *model.AppError) {
 	var email *model.Email
+
 	p, err := c.GetProfile()
 	if err != nil {
 		return nil, err
 	}
-	email, err = p.Reply(c.email, []byte(text))
 
+	email, err = p.Reply(c.email, []byte(text))
 	if err != nil {
 		return nil, err
 	}

--- a/providers/email/login.go
+++ b/providers/email/login.go
@@ -28,5 +28,6 @@ func (a *loginAuth) Next(fromServer []byte, more bool) ([]byte, error) {
 			return nil, errors.New("unknown fromServer")
 		}
 	}
+
 	return nil, nil
 }

--- a/providers/email/oauth2.go
+++ b/providers/email/oauth2.go
@@ -30,7 +30,8 @@ type xoauth2Client struct {
 func (a *xoauth2Client) Start() (mech string, ir []byte, err error) {
 	mech = Xoauth2
 	ir = []byte("user=" + a.Username + "\x01auth=Bearer " + a.Token + "\x01\x01")
-	return
+
+	return mech, ir, err
 }
 
 func (a *xoauth2Client) Next(challenge []byte) ([]byte, error) {

--- a/providers/email/profile.go
+++ b/providers/email/profile.go
@@ -1,12 +1,13 @@
 package email
 
 import (
+	"bytes"
 	"context"
 	"crypto/tls"
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
+	"mime"
 	"net"
 	"net/http"
 	"net/smtp"
@@ -17,6 +18,7 @@ import (
 
 	"github.com/emersion/go-imap"
 	"github.com/emersion/go-imap/client"
+	"github.com/emersion/go-message/charset"
 	"github.com/emersion/go-message/mail"
 	"github.com/k3a/html2text"
 	"golang.org/x/oauth2"
@@ -25,11 +27,11 @@ import (
 	"github.com/webitel/wlog"
 
 	"github.com/webitel/flow_manager/model"
-
-	_ "github.com/emersion/go-message/charset"
 )
 
 type Profile struct {
+	sync.RWMutex
+
 	Id        int
 	DomainId  int64
 	updatedAt int64
@@ -47,7 +49,6 @@ type Profile struct {
 	flowId int
 
 	server *MailServer
-	sync.RWMutex
 	client *client.Client
 
 	mbox        *imap.MailboxStatus
@@ -58,6 +59,7 @@ type Profile struct {
 	token       *oauth2.Token
 	Tls         bool
 	log         *wlog.Logger
+	decoder     *mime.WordDecoder
 }
 
 func newProfile(srv *MailServer, params *model.EmailProfile) *Profile {
@@ -84,12 +86,11 @@ func newProfile(srv *MailServer, params *model.EmailProfile) *Profile {
 			wlog.Int("profile_id", params.Id),
 			wlog.Int("schema_id", params.FlowId),
 		),
+		decoder: &mime.WordDecoder{CharsetReader: charset.Reader},
 	}
 }
 
-func (p *Profile) String() string {
-	return fmt.Sprintf("%s <%s>", p.name, p.login)
-}
+func (p *Profile) String() string { return fmt.Sprintf("%s <%s>", p.name, p.login) }
 
 func (p *Profile) Login() *model.AppError {
 	done := make(chan *model.AppError)
@@ -97,11 +98,13 @@ func (p *Profile) Login() *model.AppError {
 	go func() {
 		done <- p.clientLogin()
 	}()
+
 	select {
 	case err := <-done:
 		if err != nil {
 			return err
 		}
+
 		return nil
 	case <-time.After(time.Minute):
 		return model.NewAppError("Email", "email.login.timeout", nil, "Timeout", 500)
@@ -117,6 +120,7 @@ func (p *Profile) clientLogin() *model.AppError {
 	}
 
 	p.logged = false
+
 	var err error
 
 	var tlsConfig *tls.Config
@@ -128,6 +132,7 @@ func (p *Profile) clientLogin() *model.AppError {
 
 	dialer := new(net.Dialer)
 	dialer.Timeout = time.Second * 20
+
 	p.client, err = client.DialWithDialerTLS(dialer, fmt.Sprintf("%s:%d", p.imapHost, p.imapPort), tlsConfig)
 	if err != nil {
 		return model.NewAppError("Email", "email.dial.app_err", nil, err.Error(), http.StatusInternalServerError)
@@ -139,6 +144,7 @@ func (p *Profile) clientLogin() *model.AppError {
 
 	if p.authMethod == model.MailAuthTypeOAuth2 {
 		var ok bool
+
 		ok, err = p.client.SupportAuth(Xoauth2)
 		if err != nil {
 			return model.NewAppError("Email", "email.xoauth2.support", nil, err.Error(), http.StatusInternalServerError)
@@ -155,6 +161,7 @@ func (p *Profile) clientLogin() *model.AppError {
 		lastExpiry := p.token.Expiry
 
 		ts := p.oauthConfig.TokenSource(context.Background(), p.token)
+
 		newToken, err := ts.Token()
 		if err != nil {
 			return model.NewAppError("Email", "email.login.token", nil, err.Error(), http.StatusUnauthorized)
@@ -177,8 +184,10 @@ func (p *Profile) clientLogin() *model.AppError {
 			return model.NewAppError("Email", "email.login.unauthorized", nil, err.Error(), http.StatusUnauthorized)
 		}
 	}
+
 	p.log.Debug("logged in")
 	p.logged = true
+
 	return nil
 }
 
@@ -194,10 +203,12 @@ func (p *Profile) Logout() *model.AppError {
 	if err != nil {
 		return model.NewAppError("Email", "email.logout.app_err", nil, err.Error(), http.StatusInternalServerError)
 	}
+
 	p.logged = false
 	p.client.Close()
 	p.client = nil
 	p.log.Debug("logged out")
+
 	return nil
 }
 
@@ -210,6 +221,7 @@ func (p *Profile) UpdatedAt() int64 {
 
 func (p *Profile) selectMailBox() *model.AppError {
 	var err error
+
 	p.mbox, err = p.client.Select(p.Mailbox, false)
 	if err != nil {
 		return model.NewAppError("Email", "email.mailbox.app_err", nil, err.Error(), http.StatusInternalServerError)
@@ -218,21 +230,16 @@ func (p *Profile) selectMailBox() *model.AppError {
 	return nil
 }
 
-func (p *Profile) storeErr(err *model.AppError) {
-	p.server.storeError(p, err)
-}
-
-func (p *Profile) storeToken(token *oauth2.Token) {
-	p.server.storeToken(p, token)
-}
+func (p *Profile) storeErr(err *model.AppError)   { p.server.storeError(p, err) }
+func (p *Profile) storeToken(token *oauth2.Token) { p.server.storeToken(p, token) }
 
 func (p *Profile) Read() ([]*model.Email, *model.AppError) {
 	if !p.logged {
 		if err := p.Login(); err != nil {
 			return nil, err
 		}
-		// return nil, model.NewAppError("Email", "email.mailbox.not_logged", nil, "Profile not logged", http.StatusInternalServerError)
 	}
+
 	res := make([]*model.Email, 0)
 
 	criteria := imap.NewSearchCriteria()
@@ -240,6 +247,7 @@ func (p *Profile) Read() ([]*model.Email, *model.AppError) {
 
 	if err := p.selectMailBox(); err != nil {
 		p.storeErr(err)
+
 		return nil, err
 	}
 
@@ -247,6 +255,7 @@ func (p *Profile) Read() ([]*model.Email, *model.AppError) {
 	if err != nil {
 		appErr := model.NewAppError("Email", "email.mailbox.search.app_err", nil, err.Error(), http.StatusInternalServerError)
 		p.storeErr(appErr)
+
 		return nil, appErr
 	}
 
@@ -256,6 +265,7 @@ func (p *Profile) Read() ([]*model.Email, *model.AppError) {
 
 	seqSet := new(imap.SeqSet)
 	seqSet.AddNum(uids...)
+
 	section := &imap.BodySectionName{}
 	items := []imap.FetchItem{imap.FetchEnvelope, imap.FetchFlags, imap.FetchInternalDate, section.FetchItem()}
 	messages := make(chan *imap.Message)
@@ -264,8 +274,9 @@ func (p *Profile) Read() ([]*model.Email, *model.AppError) {
 
 	go func() {
 		if err := p.client.UidFetch(seqSet, items, messages); err != nil {
-			// log.Fatal(err) //TODO
+			p.log.Error("fetching client UID", wlog.Err(err))
 		}
+
 		close(done)
 	}()
 
@@ -273,6 +284,7 @@ func (p *Profile) Read() ([]*model.Email, *model.AppError) {
 		e, err := p.parseMessage(msg, section)
 		if err != nil {
 			p.log.Err(err)
+
 			continue
 		}
 
@@ -281,6 +293,7 @@ func (p *Profile) Read() ([]*model.Email, *model.AppError) {
 	}
 
 	<-done
+
 	return res, nil
 }
 
@@ -323,6 +336,7 @@ func (p *Profile) Reply(parent *model.Email, data []byte) (*model.Email, *model.
 	}
 
 	mail.SetBody("text/html", string(rr.HtmlBody))
+
 	var dialer *gomail.Dialer
 
 	if p.authMethod == model.MailAuthTypeOAuth2 {
@@ -331,6 +345,7 @@ func (p *Profile) Reply(parent *model.Email, data []byte) (*model.Email, *model.
 			wlog.String("smtpHost", p.smtpHost),
 			wlog.Int("smtpPort", p.smtpPort),
 		)
+
 		dialer = gomail.NewDialer(p.smtpHost, p.smtpPort, p.login, "")
 		if p.token != nil && p.token.AccessToken != "" {
 			dialer.Auth = NewOAuth2Smtp(p.login, "Bearer", p.token.AccessToken)
@@ -353,136 +368,194 @@ func (p *Profile) Reply(parent *model.Email, data []byte) (*model.Email, *model.
 	return rr, nil
 }
 
-func (p *Profile) parseMessage(msg *imap.Message, section *imap.BodySectionName) (*model.Email, *model.AppError) {
-	m := &model.Email{
-		ProfileId: p.Id,
-		Direction: "inbound", // TODO
+func prepareBodySection(msg *imap.Message, section *imap.BodySectionName) (imap.Literal, *model.AppError) {
+	if msg == nil {
+		return nil, model.NewAppError("Email", "email.message.app_err", nil, "Server didn't returned message", http.StatusInternalServerError)
 	}
 
-	if msg == nil {
-		return nil, model.NewAppError("Email", "email.message.app_err", nil, "Server didn't returned message",
-			http.StatusInternalServerError)
+	if msg.Envelope == nil {
+		return nil, model.NewAppError("Email", "email.message.app_err", nil, "Message does`nt contain envelope", http.StatusInternalServerError)
 	}
 
 	r := msg.GetBody(section)
 	if r == nil {
-		return nil, model.NewAppError("Email", "email.message.app_err", nil, "Server didn't returned message body",
-			http.StatusInternalServerError)
+		return nil, model.NewAppError("Email", "email.message.app_err", nil, "Server didn't returned message body", http.StatusInternalServerError)
 	}
 
-	m.Subject = msg.Envelope.Subject
-	for _, v := range msg.Envelope.From {
-		m.From = append(m.From, v.Address())
-	}
-	for _, v := range msg.Envelope.Sender {
-		m.Sender = append(m.Sender, v.Address())
-	}
-	for _, v := range msg.Envelope.ReplyTo {
-		m.ReplyTo = append(m.ReplyTo, v.Address())
-	}
-	for _, v := range msg.Envelope.To {
-		m.To = append(m.To, v.Address())
-	}
-	for _, v := range msg.Envelope.Cc {
-		m.CC = append(m.CC, v.Address())
-	}
-	m.InReplyTo = msg.Envelope.InReplyTo
-	m.MessageId = msg.Envelope.MessageId
+	return r, nil
+}
 
-	// Create a new mail reader
-	mr, err := mail.CreateReader(r)
+func decodeAddress(address []*imap.Address, decoder *mime.WordDecoder) []string {
+	strAddrs := make([]string, 0, len(address))
+	for _, a := range address {
+		s := a.Address()
+		if parser, err := decoder.DecodeHeader(s); err == nil {
+			strAddrs = append(strAddrs, parser)
+
+			continue
+		}
+
+		strAddrs = append(strAddrs, s)
+	}
+
+	return strAddrs
+}
+
+func decodeText(s string, decoder *mime.WordDecoder) string {
+	if d, err := decoder.DecodeHeader(s); err == nil {
+		return d
+	}
+
+	return s
+}
+
+func createEmailFromEnvelope(profileID int, envelope *imap.Envelope, decoder *mime.WordDecoder) *model.Email {
+	return &model.Email{
+		Direction: model.MailDirectionInbound,
+		MessageId: envelope.MessageId,
+		Subject:   decodeText(envelope.Subject, decoder),
+		ProfileId: profileID,
+		From:      decodeAddress(envelope.From, decoder),
+		To:        decodeAddress(envelope.To, decoder),
+		Sender:    decodeAddress(envelope.Sender, decoder),
+		ReplyTo:   decodeAddress(envelope.ReplyTo, decoder),
+		InReplyTo: decodeText(envelope.InReplyTo, decoder),
+		CC:        decodeAddress(envelope.Cc, decoder),
+		Cid:       make(map[string]model.EmailCid),
+	}
+}
+
+func (p *Profile) parseMessage(msg *imap.Message, section *imap.BodySectionName) (*model.Email, *model.AppError) {
+	bodySection, werr := prepareBodySection(msg, section)
+	if werr != nil {
+		return nil, werr
+	}
+
+	receivedMail := createEmailFromEnvelope(p.Id, msg.Envelope, p.decoder)
+	logger := p.log.With(wlog.String("message_id", receivedMail.MessageId), wlog.Any("from", receivedMail.From))
+
+	mr, err := mail.CreateReader(bodySection)
 	if err != nil {
-		return nil, model.NewAppError("Email", "email.message.app_err", nil, err.Error(),
-			http.StatusInternalServerError)
+		return nil, model.NewAppError("Email", "email.message.app_err", nil, err.Error(), http.StatusInternalServerError)
 	}
+	defer mr.Close()
 
-	var text []byte
-	var html []byte
+	it := NewMailIterator(mr, logger)
 
-	m.Cid = make(map[string]model.EmailCid)
+	//	TODO: remove after creating high level context that will pass to this func,
+	// 	with span id for OTEL integrity
+	handlersCtx := context.TODO()
 
-	// Process each message's part
-	var part *mail.Part
-	for {
-		part, err = mr.NextPart()
-		if err == io.EOF {
-			break
-		} else if err != nil {
-			p.log.Error(err.Error(), wlog.String("message-id", m.MessageId),
-				wlog.Any("from", m.From),
-			)
-			break
-		}
+	var text, html []byte
 
-		if part == nil {
-			p.log.Error("empty part", wlog.String("message-id", m.MessageId),
-				wlog.Any("from", m.From),
-			)
-			break
-		}
+	for it.Next() {
+		part := it.Part()
 
 		switch h := part.Header.(type) {
 		case *mail.InlineHeader:
-			cid := h.Get("Content-ID")
-			if cid != "" {
-				var file model.File
-				cid = strings.Trim(cid, "<>")
-				file, err = p.server.storage.Upload(context.TODO(), p.DomainId, m.MessageId, part.Body, model.File{
-					Name:     cid,
-					MimeType: h.Get("Content-Type"),
-					Channel:  model.FileChannelMail,
-				})
-				if err != nil {
-					p.log.With(wlog.Any("from", m.From)).Error(err.Error(), wlog.Err(err))
-					continue
-				}
-				m.Cid[cid] = model.EmailCid(file.Id)
-			}
-			ct := h.Get("Content-Type")
-			// This is the message's text (can be plain-text or HTML)
-			b, _ := ioutil.ReadAll(part.Body)
-			if strings.HasPrefix(ct, "text/html") {
-				html = b
-			} else if strings.HasPrefix(ct, "text/") {
-				text = append(text, b...)
-			}
-		case *mail.AttachmentHeader:
-			var fileName string
-			fileName, err = h.Filename()
+			bodyText, bodyHtml, err := p.inlineHeaderHandler(handlersCtx, h, part.Body, receivedMail)
 			if err != nil {
-				p.log.With(wlog.Any("from", m.From)).Err(err)
+				logger.Error("processing inline header, continue to next part", wlog.Err(err))
+
 				continue
-			}
-			if fileName == "" {
-				fileName = model.NewId()
 			}
 
-			var file model.File
-			file, err = p.server.storage.Upload(context.TODO(), p.DomainId, m.MessageId, part.Body, model.File{
-				Name:     fileName,
-				MimeType: h.Get("Content-Type"),
-				Channel:  model.FileChannelMail,
-			})
-			if err != nil {
-				p.log.With(wlog.Any("from", m.From)).Error(err.Error(), wlog.Err(err))
+			if len(bodyText) > 0 {
+				text = append(text, bodyText...)
+			}
+
+			if len(bodyHtml) > 0 {
+				html = bodyHtml
+			}
+		case *mail.AttachmentHeader:
+			if err := p.attachmentHeaderHandler(handlersCtx, h, part.Body, receivedMail); err != nil {
+				logger.Error("processing attachment header of mail, continue to next part", wlog.Err(err))
+
 				continue
 			}
-			m.Attachments = append(m.Attachments, file)
 		}
 	}
 
+	if err := it.Err(); err != nil {
+		return nil, err
+	}
+
+	text = resolveMailMessageText(text, html)
+
+	receivedMail.SetBody(text, html).SetHTMLBody(html)
+
+	return receivedMail, nil
+}
+
+func (p *Profile) inlineHeaderHandler(ctx context.Context, inlineHeader *mail.InlineHeader, body io.Reader, receivedMail *model.Email) ([]byte, []byte, error) {
+	b, err := io.ReadAll(body)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	contentType := inlineHeader.Get("Content-Type")
+
+	var text, html []byte
+	if strings.HasPrefix(contentType, "text/html") {
+		html = b
+	} else if strings.HasPrefix(contentType, "text/") {
+		text = append(text, b...)
+	}
+
+	cid := strings.Trim(inlineHeader.Get("Content-ID"), "<>")
+
+	if cid == "" {
+		return text, html, nil
+	}
+
+	file, err := p.server.storage.Upload(
+		ctx,
+		p.DomainId,
+		receivedMail.MessageId,
+		bytes.NewReader(b),
+		model.File{Name: cid, MimeType: contentType, Channel: model.FileChannelMail},
+	)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	receivedMail.AddCID(cid, file.Id)
+
+	return text, html, nil
+}
+
+func (p *Profile) attachmentHeaderHandler(ctx context.Context, attachmentHeader *mail.AttachmentHeader, body io.Reader, receivedMail *model.Email) error {
+	fileName, err := attachmentHeader.Filename()
+	if err != nil {
+		return err
+	}
+
+	if fileName == "" {
+		fileName = model.NewId()
+	}
+
+	file, err := p.server.storage.Upload(
+		ctx,
+		p.DomainId,
+		receivedMail.MessageId,
+		body,
+		model.File{Name: fileName, MimeType: attachmentHeader.Get("Content-Type"), Channel: model.FileChannelMail},
+	)
+	if err != nil {
+		return err
+	}
+
+	receivedMail.AddAttachment(file)
+
+	return nil
+}
+
+func resolveMailMessageText(text, html []byte) []byte {
 	if len(text) == 0 && len(html) != 0 {
-		text = []byte(html2text.HTML2Text(string(html)))
+		return []byte(html2text.HTML2Text(string(html)))
 	}
 
-	if text != nil {
-		m.Body = text
-	} else {
-		m.Body = html
-	}
-	m.HtmlBody = html
-
-	return m, nil
+	return text
 }
 
 type OAuth2Smtp struct {
@@ -501,7 +574,9 @@ func (a *OAuth2Smtp) Start(server *smtp.ServerInfo) (string, []byte, error) {
 	if !server.TLS {
 		return "", nil, errors.New("unencrypted connection")
 	}
-	resp := []byte(fmt.Sprintf("user=%v\001auth=%v %v\001\001", a.user, "Bearer", a.token))
+
+	resp := fmt.Appendf(nil, "user=%v\001auth=%v %v\001\001", a.user, "Bearer", a.token)
+
 	return "XOAUTH2", resp, nil
 }
 
@@ -510,5 +585,6 @@ func (a *OAuth2Smtp) Next(fromServer []byte, more bool) ([]byte, error) {
 		// We've already sent everything.
 		return nil, fmt.Errorf("unexpected server challenge: %s", fromServer)
 	}
+
 	return nil, nil
 }

--- a/providers/email/reader_iterator.go
+++ b/providers/email/reader_iterator.go
@@ -1,0 +1,60 @@
+package email
+
+import (
+	"errors"
+	"io"
+	"net/http"
+
+	"github.com/emersion/go-message/mail"
+
+	"github.com/webitel/wlog"
+
+	"github.com/webitel/flow_manager/model"
+)
+
+type MailPartReader interface {
+	NextPart() (*mail.Part, error)
+}
+
+type MailIterator struct {
+	reader MailPartReader
+	logger *wlog.Logger
+	curr   *mail.Part
+	err    *model.AppError
+}
+
+func NewMailIterator(reader MailPartReader, logger *wlog.Logger) *MailIterator {
+	return &MailIterator{reader: reader, logger: logger}
+}
+
+func (it *MailIterator) Next() bool {
+	if it.err != nil {
+		return false
+	}
+
+	part, err := it.reader.NextPart()
+	if err != nil {
+		if !errors.Is(err, io.EOF) {
+			it.logger.Error("getting next part from mail reader", wlog.Err(err))
+			it.err = model.NewAppError("Next", "email.reader_iterator.next_part", nil, err.Error(), http.StatusInternalServerError)
+		}
+
+		it.curr = nil
+
+		return false
+	}
+
+	if part == nil {
+		it.logger.Warn("empty part")
+		it.curr = nil
+
+		return false
+	}
+
+	it.curr = part
+
+	return true
+}
+
+func (it *MailIterator) Part() *mail.Part     { return it.curr }
+func (it *MailIterator) Err() *model.AppError { return it.err }

--- a/providers/email/server.go
+++ b/providers/email/server.go
@@ -3,18 +3,19 @@ package email
 import (
 	"context"
 	"fmt"
-	"golang.org/x/sync/singleflight"
 	"io"
 	"net/http"
 	"sync"
 	"time"
 
 	"golang.org/x/oauth2"
+	"golang.org/x/sync/singleflight"
 
 	"github.com/webitel/engine/pkg/discovery"
+	"github.com/webitel/wlog"
+
 	"github.com/webitel/flow_manager/model"
 	"github.com/webitel/flow_manager/store"
-	"github.com/webitel/wlog"
 )
 
 var (
@@ -24,6 +25,8 @@ var (
 )
 
 type MailServer struct {
+	sync.RWMutex
+
 	store           store.EmailStore
 	storage         StorageApi
 	profiles        *model.Cache
@@ -33,8 +36,7 @@ type MailServer struct {
 	consume         chan model.Connection
 	running         map[int]bool
 	debug           bool
-	sync.RWMutex
-	log *wlog.Logger
+	log             *wlog.Logger
 }
 
 type StorageApi interface {
@@ -55,18 +57,15 @@ func New(storageApi StorageApi, s store.EmailStore, debug bool) model.Server {
 	}
 }
 
-func (s *MailServer) Name() string {
-	return "Email"
-}
+func (s *MailServer) Name() string { return "Email" }
 
-func (s *MailServer) Cluster(discovery discovery.ServiceDiscovery) *model.AppError {
-	return nil
-}
+func (s *MailServer) Cluster(discovery discovery.ServiceDiscovery) *model.AppError { return nil }
 
 func (s *MailServer) Start() *model.AppError {
 	s.startOnce.Do(func() {
 		go s.listen()
 	})
+
 	return nil
 }
 
@@ -75,21 +74,10 @@ func (s *MailServer) Stop() {
 	<-s.stopped
 }
 
-func (s *MailServer) Host() string {
-	return "" //TODO
-}
-
-func (s *MailServer) Port() int {
-	return 0
-}
-
-func (s *MailServer) Type() model.ConnectionType {
-	return model.ConnectionTypeEmail
-}
-
-func (s *MailServer) Consume() <-chan model.Connection {
-	return s.consume
-}
+func (s *MailServer) Host() string                     { return "" } // TODO
+func (s *MailServer) Port() int                        { return 0 }
+func (s *MailServer) Type() model.ConnectionType       { return model.ConnectionTypeEmail }
+func (s *MailServer) Consume() <-chan model.Connection { return s.consume }
 
 func (s *MailServer) startRunning(id int) {
 	s.Lock()
@@ -107,6 +95,7 @@ func (s *MailServer) hasRunning(id int) bool {
 	s.RLock()
 	_, ok := s.running[id]
 	s.RUnlock()
+
 	return ok
 }
 
@@ -117,6 +106,7 @@ func (s *MailServer) listen() {
 	}()
 
 	s.log.Debug("start listen emails")
+
 	for {
 		select {
 		case <-s.didFinishListen:
@@ -124,34 +114,35 @@ func (s *MailServer) listen() {
 		case <-time.After(FetchProfileInterval):
 			tasks, err := s.store.ProfileTaskFetch("")
 			if err != nil {
-				s.log.Error(err.Error())
+				s.log.Error("fetching profile tasks", wlog.Err(err))
 				time.Sleep(time.Second * 5)
-			} else {
-				for _, v := range tasks {
-					if !s.hasRunning(v.Id) {
-						s.startRunning(v.Id)
-						go func(p *model.EmailProfileTask) {
-							s.fetchNewMessageInProfile(p)
-							s.stopRunning(p.Id)
-						}(v)
-					}
+
+				break
+			}
+
+			for _, v := range tasks {
+				if s.hasRunning(v.Id) {
+					continue
 				}
+
+				s.startRunning(v.Id)
+				go func(p *model.EmailProfileTask) {
+					s.fetchNewMessageInProfile(p)
+					s.stopRunning(p.Id)
+				}(v)
 			}
 		}
 	}
 }
 
 func (s *MailServer) GetProfile(id int, updatedAt int64) (*Profile, *model.AppError) {
-	var pp *Profile
-	profile, ok := s.profiles.Get(id)
-	if ok {
-		pp = profile.(*Profile)
-		if updatedAt == pp.UpdatedAt() {
-			return pp, nil
+	if profile, ok := s.profiles.Get(id); ok {
+		if asserted, ok := profile.(*Profile); ok {
+			return asserted, nil
 		}
 	}
 
-	v, doErr, shared := profileSGroup.Do(fmt.Sprintf("%d-%d", id, updatedAt), func() (interface{}, error) {
+	v, doErr, shared := profileSGroup.Do(fmt.Sprintf("%d-%d", id, updatedAt), func() (any, error) {
 		params, err := s.store.GetProfile(id)
 		if err != nil {
 			return nil, err
@@ -159,17 +150,21 @@ func (s *MailServer) GetProfile(id int, updatedAt int64) (*Profile, *model.AppEr
 
 		return newProfile(s, params), nil
 	})
-
 	if doErr != nil {
-		switch doErr.(type) {
+		switch doErr := doErr.(type) {
 		case *model.AppError:
-			return nil, doErr.(*model.AppError)
+			return nil, doErr
 		default:
 			return nil, model.NewAppError("Email", "email.profile.create.app_err", nil, doErr.Error(), http.StatusInternalServerError)
 		}
 	}
 
-	pp = v.(*Profile)
+	pp, ok := v.(*Profile)
+	if !ok {
+		s.log.Error("asserting profile single flight group", wlog.String("v_type", fmt.Sprintf("%T", v)))
+
+		return nil, model.NewAppError("GetProfile", "email.server.profile_assert", nil, "asserting other type", 500)
+	}
 
 	if !shared {
 		s.profiles.Add(id, pp)
@@ -183,6 +178,7 @@ func (s *MailServer) fetchNewMessageInProfile(p *model.EmailProfileTask) {
 	if err != nil {
 		s.storeError(profile, err)
 		s.log.Error(fmt.Sprintf("profile \"%s\", error: %s", profile, err.Error()))
+
 		return
 	}
 
@@ -190,29 +186,36 @@ func (s *MailServer) fetchNewMessageInProfile(p *model.EmailProfileTask) {
 
 retry:
 	err = profile.Login()
+
 	if err != nil {
 		s.storeError(profile, err)
 		s.log.Error(fmt.Sprintf("profile \"%s\", error: %s", profile, err.Error()))
 	}
 
 	var emails []*model.Email
+
 	emails, err = profile.Read()
 	if err != nil {
 		if err.DetailedError == "Not logged in" {
 			if attempts == 0 {
-				attempts = attempts + 1
+				attempts++
+
 				goto retry
 			}
 		}
+
 		s.log.Error(fmt.Sprintf("[%s] error: %s", profile, err.Error()))
+
 		return
 	}
 
 	for _, email := range emails {
 		if err = s.store.Save(profile.DomainId, email); err != nil {
 			s.log.Err(err)
+
 			continue
 		}
+
 		s.consume <- NewConnection(s, PKey{
 			Id:        profile.Id,
 			UpdatedAt: p.UpdatedAt,
@@ -220,6 +223,7 @@ retry:
 			DomainId:  profile.DomainId,
 		}, email)
 	}
+
 	err = profile.Logout()
 	if err != nil {
 		s.storeError(profile, err)
@@ -232,6 +236,7 @@ func (s *MailServer) storeError(p *Profile, err *model.AppError) {
 	if saveErr != nil {
 		s.log.Err(saveErr)
 	}
+
 	s.profiles.Remove(p.Id)
 }
 
@@ -244,6 +249,7 @@ func (s *MailServer) storeToken(p *Profile, token *oauth2.Token) {
 
 func (s *MailServer) TestProfile(domainId int64, profileId int) *model.AppError {
 	var profile *Profile
+
 	updatedAt, err := s.store.GetProfileUpdatedAt(domainId, profileId)
 	if err != nil {
 		return err


### PR DESCRIPTION
- add envelope entity decoding of `Address` fields; as current version of email implementation in `webitel-flow-manager` used v1 version of [go-imap](https://github.com/emersion/go-imap/tree/v1) lib it is not possible to use next [dial client wrapper](https://github.com/emersion/go-imap/blob/v2/imapclient/client.go#L77), so I implement methods for manual decoding of email fields into correct utf-8 format as it used in v2 version of lib: [example for text](https://github.com/emersion/go-imap/blob/v2/imapclient/client.go#L96);

- add `iterator` implementation to iterate through mail parts and encapsulate logic for getting part and check if has next
- improve struct logger using
- break main function for processing mail message into more small functions to use SR SOLID principle
- add factory function for creating domain `Email` model from imap Envelope structure, thar encapsulate mapping logic
- run golangci-lint to format files at providers/email package