### PR TITLE
fix(buf): track protos main branch on main

### DIFF
--- a/buf/buf.gen.cases.yaml
+++ b/buf/buf.gen.cases.yaml
@@ -26,5 +26,5 @@ plugins:
 inputs:
 #  - directory: "../protos/cases"
   - git_repo: "https://github.com/webitel/protos"
-    branch: "v26.02"
+    branch: "main"
     subdir: cases

--- a/buf/buf.gen.chat.yaml
+++ b/buf/buf.gen.chat.yaml
@@ -26,5 +26,5 @@ plugins:
 inputs:
 #  - directory: "../protos/chat"
   - git_repo: "https://github.com/webitel/protos"
-    branch: "v26.02"
+    branch: "main"
     subdir: chat

--- a/buf/buf.gen.engine.yaml
+++ b/buf/buf.gen.engine.yaml
@@ -15,7 +15,7 @@ plugins:
 inputs:
 #  - directory: "../protos/engine"
   - git_repo: "https://github.com/webitel/protos"
-    branch: "v26.02"
+    branch: "main"
     subdir: engine
     types:
       - engine.Lookup

--- a/buf/buf.gen.general.yaml
+++ b/buf/buf.gen.general.yaml
@@ -15,5 +15,5 @@ plugins:
 inputs:
 #  - directory: "../protos/general"
   - git_repo: "https://github.com/webitel/protos"
-    branch: "v26.02"
+    branch: "main"
     subdir: general

--- a/buf/buf.gen.storage.yaml
+++ b/buf/buf.gen.storage.yaml
@@ -22,7 +22,7 @@ plugins:
 inputs:
 #  - directory: "../protos/storage"
   - git_repo: "https://github.com/webitel/protos"
-    branch: "v26.02"
+    branch: "main"
     subdir: storage
     types:
       - storage.FileService

--- a/buf/buf.gen.wbt.yaml
+++ b/buf/buf.gen.wbt.yaml
@@ -24,7 +24,7 @@ plugins:
 inputs:
 #  - directory: "../protos/webitel-go"
   - git_repo: "https://github.com/webitel/protos"
-    branch: "v26.02"
+    branch: "main"
     subdir: webitel-go
     types:
       - webitel.contacts.Contacts

--- a/buf/buf.gen.yaml
+++ b/buf/buf.gen.yaml
@@ -22,5 +22,5 @@ plugins:
 inputs:
 #  - directory: "../protos/workflow"
   - git_repo: "https://github.com/webitel/protos"
-    branch: "v26.02"
+    branch: "main"
     subdir: workflow


### PR DESCRIPTION
## What
Point the drifted `buf` proto inputs back at `github.com/webitel/protos` **main** on the `main` branch (they were pinned to a release branch).

## Why
On `main`, buf must track protos `main`; pinning to a release branch belongs only on release branches.

## Note
Config-only change; no generated code is regenerated here.