### PR TITLE
WTEL-9794: Fix Today filter timezone in patchMembers

### DIFF
--- a/store/pg_store/member_store.go
+++ b/store/pg_store/member_store.go
@@ -195,6 +195,7 @@ func (s SqlMemberStore) PatchMembers(domainId int64, req *model.SearchMember, pa
         variables = case when (:UVariables::jsonb) notnull then coalesce(mu.variables, '{}'::jsonb) || :UVariables::jsonb else mu.variables end,
         communications = case when :Communications::jsonb notnull and x.v notnull then x.v else mu.communications end
     from call_center.cc_member m
+        left join flow.calendar_timezones tz on tz.id = m.timezone_id
         left join lateral (
             select
                 jsonb_agg(case when d notnull then x.comm || (d - '{"id"}') else x.comm end order by idx) v
@@ -207,7 +208,8 @@ func (s SqlMemberStore) PatchMembers(domainId int64, req *model.SearchMember, pa
     )
     and (:Name::varchar isnull or m.name ilike :Name)
     and (:Id::int8 isnull or m.id = :Id::int8)
-    and (:Today::bool isnull or not :Today::bool or (:Today and m.created_at >= now()::date))
+    and (:Today::bool isnull or not :Today::bool
+        or (m.created_at at time zone coalesce(tz.sys_name, 'UTC'))::date = (now() at time zone coalesce(tz.sys_name, 'UTC'))::date)
     and (:Completed::bool isnull or ( case when :Completed then not m.stop_at isnull else m.stop_at isnull end ))
     and (:BucketId::int isnull or m.bucket_id = :BucketId)
     and (:Destination::varchar isnull or m.communications @>  any (array((select jsonb_build_array(jsonb_build_object('destination', :Destination::varchar))))))


### PR DESCRIPTION
## Проблема
Фільтр today у patchMembers порівнював created_at з now()::date, тобто рахував "сьогодні" за поясом сервера БД (UTC) і ігнорував часовий пояс мембера. 

## Вирішення
"Сьогодні" тепер обчислюється в поясі мембера: join flow.calendar_timezones по m.timezone_id і порівняння локальних дат через at time zone.

## Зміни
- SqlMemberStore.PatchMembers: доданий join словника поясів